### PR TITLE
Remove opensearch.version parameter in CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Build and Run Tests
       run: |
-          ./gradlew build -Dopensearch.version=1.2.3
+          ./gradlew build


### PR DESCRIPTION
CI tests should be run against the opensearch version specified in build.gradle

Closes #24

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>